### PR TITLE
Create setup.py file to make it easy to import magvit2 into other projects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,13 @@
-from setuptools import find_packages, find_namespace_packages, setup
+from setuptools import find_namespace_packages, setup
 
-with open('requirements.txt') as f:
-    required = f.read().splitlines()
+def parse_requirements(filename):
+    with open(filename) as f:
+        lines = f.read().splitlines()
+    return [line.strip() for line in lines if line.strip() and not line.strip().startswith('#')]
 
 setup(
     name="magvit2",
     version="1.0",
     packages=find_namespace_packages(include=['taming.*']),
+    install_requires=parse_requirements('requirements.txt'),
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import find_packages, find_namespace_packages, setup
+
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
+
+setup(
+    name="magvit2",
+    version="1.0",
+    packages=find_namespace_packages(include=['taming.*']),
+)


### PR DESCRIPTION
`pip install -e magvit2` now installs all dependencies and makes it possible to do `from taming.models.lfqgan import VQModel` from anywhere (not just when cwd=Open-MAGVIT2)

Let me know if this is helpful